### PR TITLE
Feature/battery level warning

### DIFF
--- a/custom.ts
+++ b/custom.ts
@@ -354,6 +354,8 @@ namespace gigglebot {
         power_left = ((motor_power_left * -1 * input.acceleration(Dimension.Y)) / 1024) + ((50 * input.acceleration(Dimension.X)) / 1024)
         power_right = ((motor_power_right * -1 * input.acceleration(Dimension.Y)) / 1024) - ((50 * input.acceleration(Dimension.X)) / 1024)
         radio.sendValue(power_left+"", power_right)
+        // basic.pause(10)
+        // radio.sendValue("right", power_right)
     }
 
     const packet = new radio.Packet();

--- a/custom.ts
+++ b/custom.ts
@@ -348,14 +348,12 @@ namespace gigglebot {
     //% blockId="gigglebot_remote_control"
     //% block="external remote control, group %radio_block"
     export function remote_control(radio_block: number): void {
-        let power_left = 50
-        let power_right = 50
+        let power_left = motor_power_left
+        let power_right = motor_power_right
         radio.setGroup(radio_block)
-        power_left = ((50 * input.acceleration(Dimension.Y)) / 1024) + ((50 * input.acceleration(Dimension.X)) / 1024)
-        power_right = ((50 * input.acceleration(Dimension.Y)) / 1024) - ((50 * input.acceleration(Dimension.X)) / 1024)
-        radio.sendValue("left", power_left)
-        basic.pause(10)
-        radio.sendValue("right", power_right)
+        power_left = ((motor_power_left * -1 * input.acceleration(Dimension.Y)) / 1024) + ((50 * input.acceleration(Dimension.X)) / 1024)
+        power_right = ((motor_power_right * -1 * input.acceleration(Dimension.Y)) / 1024) - ((50 * input.acceleration(Dimension.X)) / 1024)
+        radio.sendValue(power_left+"", power_right)
     }
 
     const packet = new radio.Packet();
@@ -388,12 +386,8 @@ namespace gigglebot {
     //% blockId="gigglebot_remote_control_action"
     //% block="do remote control action"
     export function remote_control_action(): void {
-        if (packet.receivedString == "left") {
-            motor_power_left = packet.receivedNumber - trim_left
-        }
-        if (packet.receivedString == "right") {
-            motor_power_right = packet.receivedNumber - trim_right
-        }
+        motor_power_left = parseInt(packet.receivedString) - trim_left
+        motor_power_right = packet.receivedNumber - trim_right
         set_motor_powers(motor_power_left, motor_power_right)
     }
 

--- a/custom.ts
+++ b/custom.ts
@@ -171,6 +171,8 @@ namespace gigglebot {
     let eyes = strip.range(0, 2)
     let left_eye_neopixel = strip.range(1, 1)
     let right_eye_neopixel = strip.range(0, 1)
+    let eye_color_left = neopixel.colors(NeoPixelColors.Blue)
+    let eye_color_right = neopixel.colors(NeoPixelColors.Blue)
     let smile = strip.range(2, 7)
     eyes.setBrightness(10)
     left_eye_neopixel.setBrightness(10)
@@ -180,8 +182,12 @@ namespace gigglebot {
         strip.setPixelColor(_i, neopixel.colors(NeoPixelColors.Black))
     }
     strip.show()
-    left_eye_neopixel.setPixelColor(0, neopixel.colors(NeoPixelColors.Blue))
-    right_eye_neopixel.setPixelColor(0, neopixel.colors(NeoPixelColors.Blue))
+    if (get_voltage() < 3400) {
+        eye_color_left = neopixel.colors(NeoPixelColors.Red)
+        eye_color_right = neopixel.colors(NeoPixelColors.Red)
+    }
+    left_eye_neopixel.setPixelColor(0, eye_color_left)
+    right_eye_neopixel.setPixelColor(0, eye_color_right)
     eyes.show()
 
 
@@ -353,7 +359,7 @@ namespace gigglebot {
         radio.setGroup(radio_block)
         power_left = ((motor_power_left * -1 * input.acceleration(Dimension.Y)) / 1024) + ((50 * input.acceleration(Dimension.X)) / 1024)
         power_right = ((motor_power_right * -1 * input.acceleration(Dimension.Y)) / 1024) - ((50 * input.acceleration(Dimension.X)) / 1024)
-        radio.sendValue(power_left+"", power_right)
+        radio.sendValue(power_left + "", power_right)
         // basic.pause(10)
         // radio.sendValue("right", power_right)
     }


### PR DESCRIPTION
if the battery voltage falls below 3.4v, then the eyes are turned red instead of blue at the start of a program.

Note that this is not fool-proof. If the user sets the eye colour to a specific colour in the OnStart block, then they won't see this warning.

Still, it's better than nothing. At least it provides an easy way for the user to verify the state of their batteries.