### PR TITLE
Trimming and motor control

### DIFF
--- a/gigglebot.ts
+++ b/gigglebot.ts
@@ -81,34 +81,6 @@ enum gigglebotLineColor {
     White
 }
 
-enum gigglebotWhichEye {
-    //% block="both eyes"
-    Both,
-    //% block="left eye"
-    Left,
-    //% block="right eye"
-    Right
-}
-
-enum gigglebotEyeAction {
-    //% block="open"
-    Open,
-    //% block="close"
-    Close
-}
-
-enum gigglebotGigglePixels {
-    Right,
-    Left,
-    SmileOne,
-    SmileTwo,
-    SmileThree,
-    SmileFour,
-    SmileFive,
-    SmileSix,
-    SmileSeven
-}
-
 enum gigglebotServoAction {
     //% block="right"
     Right,

--- a/gigglebot.ts
+++ b/gigglebot.ts
@@ -387,6 +387,7 @@ namespace gigglebot {
     /**
      * You can set the speed for each individual motor or both together. The higher the speed the less control the robot has.
      * You may need to correct the robot (see block in "more..." section).  A faster robot needs more correction than a slower one.
+     * Note that any drive correction done previously gets applied here.
      * If you want to follow a line,  it will work best at a lower speed.
      * Actual speed is dependent on the freshness of the batteries.
      * @param motor: left, right or both motors
@@ -396,7 +397,8 @@ namespace gigglebot {
     //% speed.min=-100 speed.max=100
     //% weight=60
     export function setSpeed(motor: gigglebotWhichMotor, speed: gigglebotWhichSpeed) {
-        speed = Math.min(Math.max(speed, -100), 100)
+        // no need to check as the speed value is taken from a pulldown
+        // speed = Math.min(Math.max(speed, -100), 100)
         if (motor != gigglebotWhichMotor.Left) {
             if (speed > 0)
                 motorPowerRight = speed - trimRight;
@@ -410,7 +412,7 @@ namespace gigglebot {
             else
             motorPowerLeft = speed + trimLeft;
         }
-        motorPowerAssignBoth(motorPowerLeft, motorPowerRight)
+        // motorPowerAssignBoth(motorPowerLeft, motorPowerRight)
     }
 
     ///////////////////////////////////////////////////////////////////////
@@ -614,11 +616,11 @@ namespace gigglebot {
         if (trim_value < 0) trim_value = 0
         if (dir == gigglebotWhichTurnDirection.Left) {
             trimLeft = trim_value
-            motorPowerLeft = defaultMotorPower - trimLeft
+            motorPowerLeft = motorPowerLeft - trimLeft
         }
         if (dir == gigglebotWhichTurnDirection.Right) {
             trimRight = trim_value
-            motorPowerRight = defaultMotorPower - trimRight
+            motorPowerRight = motorPowerRight - trimRight
         }
     }
 

--- a/gigglebot.ts
+++ b/gigglebot.ts
@@ -123,6 +123,8 @@ namespace gigglebot {
     let distanceSensorInitDone = false;
     let lineSensors = [0, 0]
     let lightSensors = [0, 0]
+    // turn motor power off
+    stop()
 
 
     /**

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "gigglebot",
-    "version": "v0.1.0",
+    "version": "v0.1.1",
     "dependencies": {
         "core": "*",
         "distanceSensor": "github:dexterind/pxt-distancesensor#v0.0.1"

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "gigglebot",
-    "version": "v0.1.2",
+    "version": "v0.1.3",
     "dependencies": {
         "core": "*",
         "distanceSensor": "github:dexterind/pxt-distancesensor#v0.0.1"

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "gigglebot",
-    "version": "v0.1.2
+    "version": "v0.1.2",
     "dependencies": {
         "core": "*",
         "distanceSensor": "github:dexterind/pxt-distancesensor#v0.0.1"

--- a/pxt.json
+++ b/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "gigglebot",
-    "version": "v0.1.1",
+    "version": "v0.1.2
     "dependencies": {
         "core": "*",
         "distanceSensor": "github:dexterind/pxt-distancesensor#v0.0.1"


### PR DESCRIPTION
1. motors were not turned off systematically at the beginning of each program. Now, if gigglebot becomes runaway, a simple reset of the microbit will stop it
2. trimming wasn't working properly on speeds other than normal. Trimming is still speed dependent though.
3. setting speed does not automatically start the motors. This way, users can set the speed during the "On Start" block. 
